### PR TITLE
Header, nav-bar issues and parametric endpoints

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -124,6 +124,11 @@ export default function TabLayout() {
         name="view-post"
         options={{ href: null, title: "View post" }}
       />
+
+      <Tabs.Screen
+        name="post/[post_id]"
+        options={{ href: null, title: "View post" }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -120,6 +120,10 @@ export default function TabLayout() {
         name="publish-post"
         options={{ href: null, title: "New Post" }}
       />
+      <Tabs.Screen
+        name="view-post"
+        options={{ href: null, title: "View post" }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,11 @@
-import { Tabs } from "expo-router";
+import { router, Tabs } from "expo-router";
 import React from "react";
 
 import { TabBarIcon } from "@/components/navigation/TabBarIcon";
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
+import { TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
@@ -12,7 +14,26 @@ export default function TabLayout() {
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? "light"].tint,
-        headerShown: false,
+        headerStyle: {
+          backgroundColor: "#DD614A",
+        },
+        headerTintColor: "#fff",
+        headerTitleStyle: {
+          fontWeight: "bold",
+        },
+        headerLeft: () => (
+          <TouchableOpacity
+            onPress={() => {
+              router.back();
+            }}
+          >
+            <Ionicons
+              size={28}
+              style={{ color: "white", marginLeft: 20 }}
+              name="arrow-back"
+            />
+          </TouchableOpacity>
+        ),
       }}
     >
       <Tabs.Screen
@@ -25,8 +46,11 @@ export default function TabLayout() {
               color={color}
             />
           ),
+          headerLeft: () => <></>,
+          headerTitle: "Home",
         }}
       />
+
       <Tabs.Screen
         name="photos"
         options={{
@@ -39,6 +63,7 @@ export default function TabLayout() {
           ),
         }}
       />
+
       <Tabs.Screen
         name="create-post"
         options={{
@@ -61,6 +86,7 @@ export default function TabLayout() {
           ),
         }}
       />
+
       <Tabs.Screen
         name="profile"
         options={{
@@ -70,7 +96,8 @@ export default function TabLayout() {
           ),
         }}
       />
+
+      {/* <Tabs.Screen name="publish-post" options={{ href: null }} /> */}
     </Tabs>
   );
 }
-

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { TabBarIcon } from "@/components/navigation/TabBarIcon";
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
-import { TouchableOpacity } from "react-native";
+import { Image, TouchableOpacity, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
 export default function TabLayout() {
@@ -22,6 +22,24 @@ export default function TabLayout() {
           fontWeight: "bold",
         },
         headerLeft: () => (
+          <View>
+            <TouchableOpacity
+              onPress={() => {
+                router.push("/");
+              }}
+            >
+              <Image
+                style={{
+                  height: 28,
+                  width: 28,
+                  marginLeft: 20,
+                }}
+                source={require("../../assets/images/icon.png")}
+              />
+            </TouchableOpacity>
+          </View>
+        ),
+        headerRight: () => (
           <TouchableOpacity
             onPress={() => {
               router.back();
@@ -29,12 +47,13 @@ export default function TabLayout() {
           >
             <Ionicons
               size={28}
-              style={{ color: "white", marginLeft: 20 }}
-              name="arrow-back"
+              style={{ color: "white", marginHorizontal: 20 }}
+              name="arrow-back-circle"
             />
           </TouchableOpacity>
         ),
       }}
+      backBehavior="history"
     >
       <Tabs.Screen
         name="index"
@@ -46,7 +65,7 @@ export default function TabLayout() {
               color={color}
             />
           ),
-          headerLeft: () => <></>,
+          headerRight: () => <></>,
           headerTitle: "Home",
         }}
       />

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -97,7 +97,7 @@ export default function TabLayout() {
         }}
       />
 
-      {/* <Tabs.Screen name="publish-post" options={{ href: null }} /> */}
+      <Tabs.Screen name="publish-post" options={{ href: null }} />
     </Tabs>
   );
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -116,7 +116,10 @@ export default function TabLayout() {
         }}
       />
 
-      <Tabs.Screen name="publish-post" options={{ href: null }} />
+      <Tabs.Screen
+        name="publish-post"
+        options={{ href: null, title: "New Post" }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -71,27 +71,30 @@ export default function Index() {
           }}
           style={styles.map}
         >
-          {sites.map(({ latitude, longitude, site_id, site_preview_url }) =>
-            site_preview_url ? (
-              <Marker key={site_id} coordinate={{ latitude, longitude }}>
-                <Callout
-                  onPress={() =>
-                    console.log(`You just pressed site ${site_id}!`)
-                  }
-                >
-                  <WebView
-                    source={{ uri: site_preview_url || defaultSitePreview }}
-                    style={styles.sitePreviewImg}
-                  />
-                </Callout>
-              </Marker>
-            ) : (
-              <Marker
-                pinColor={"blue"}
-                coordinate={{ latitude, longitude }}
-                key={site_id}
-              ></Marker>
-            )
+          {sites.map(
+            ({ latitude, longitude, site_id, site_preview_url, post_id }) =>
+              site_preview_url ? (
+                <Marker key={site_id} coordinate={{ latitude, longitude }}>
+                  <Callout
+                    onPress={() =>
+                      console.log(
+                        `You just pressed site ${site_id}! Go to ${post_id}`
+                      )
+                    }
+                  >
+                    <WebView
+                      source={{ uri: site_preview_url || defaultSitePreview }}
+                      style={styles.sitePreviewImg}
+                    />
+                  </Callout>
+                </Marker>
+              ) : (
+                <Marker
+                  pinColor={"blue"}
+                  coordinate={{ latitude, longitude }}
+                  key={site_id}
+                ></Marker>
+              )
           )}
         </MapView>
       </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -78,9 +78,6 @@ export default function Index() {
                 <Marker key={site_id} coordinate={{ latitude, longitude }}>
                   <Callout
                     onPress={() => {
-                      console.log(
-                        `You just pressed site ${site_id}! Go to ${post_id}`
-                      );
                       router.push(`/post/${post_id}`);
                     }}
                   >

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,6 +11,7 @@ import * as Location from "expo-location";
 import { useEffect, useState } from "react";
 import { fetchSites } from "@/client/client.mjs";
 import WebView from "react-native-webview";
+import { router } from "expo-router";
 const defaultSitePreview =
   "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/0f7bfb63-2a9d-4b1e-bdf6-08be9a3482fd/width=450/view-129-gigapixel-art-scale-2_00x.jpeg";
 
@@ -76,11 +77,12 @@ export default function Index() {
               site_preview_url ? (
                 <Marker key={site_id} coordinate={{ latitude, longitude }}>
                   <Callout
-                    onPress={() =>
+                    onPress={() => {
                       console.log(
                         `You just pressed site ${site_id}! Go to ${post_id}`
-                      )
-                    }
+                      );
+                      router.push(`/post/${post_id}`);
+                    }}
                   >
                     <WebView
                       source={{ uri: site_preview_url || defaultSitePreview }}

--- a/app/(tabs)/photos.tsx
+++ b/app/(tabs)/photos.tsx
@@ -4,39 +4,9 @@ import { useFocusEffect } from "@react-navigation/native";
 import {
   fetchPosts,
   fetchUsers,
-  fetchSiteBySiteId,
+  fetchCityForSite,
 } from "../../client/client.mjs";
 import Post from "@/components/Post";
-
-async function getCityByCoordinates(
-  latitude: number,
-  longitude: number
-): Promise<string> {
-  const url = `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json&addressdetails=1`;
-  try {
-    const response = await fetch(url);
-    const data = await response.json();
-
-    if (data && data.address) {
-      const city =
-        data.address.city || data.address.town || data.address.village || "";
-      return city;
-    } else {
-      console.log(url);
-      console.log(data);
-      return "";
-    }
-  } catch (error) {
-    console.error("Error fetching city:", error);
-    return "";
-  }
-}
-
-async function fetchCityForSite(site_id: string) {
-  const { site } = await fetchSiteBySiteId(site_id);
-  const city = await getCityByCoordinates(site.latitude, site.longitude);
-  return city;
-}
 
 export default function Photos() {
   const [posts, setPosts] = useState<any[]>([]);

--- a/app/(tabs)/post/[post_id].tsx
+++ b/app/(tabs)/post/[post_id].tsx
@@ -1,0 +1,114 @@
+import Post from "@/components/Post";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import CommentsSection from "../../../components/CommentsSection";
+import { useState, useEffect, useContext } from "react";
+import {
+  deletePostByPostId,
+  fetchCommentsByPostId,
+  fetchUserByUserId,
+} from "@/client/client.mjs";
+import { UserContext } from "@/contexts/UserContext";
+import { StyleSheet, TouchableOpacity, Alert } from "react-native";
+import Fontisto from "@expo/vector-icons/Fontisto";
+
+export default function ViewPost() {
+  const { loggedInUser } = useContext(UserContext);
+  const [comments, SetComments] = useState([]);
+  const [commentsLoading, setCommentsLoading] = useState(true);
+  const [commentAuthors, setCommentAuthors] = useState([]);
+  const { post, author, city } = useLocalSearchParams<{
+    post: string;
+    author: string;
+    city: string;
+  }>();
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const loadComments = async () => {
+      setCommentsLoading(true);
+      try {
+        const { comments } = await fetchCommentsByPostId(
+          JSON.parse(post).post_id
+        );
+        SetComments(comments);
+
+        if (comments && comments.length > 0) {
+          const commentAuthorIds = [
+            ...new Set(
+              comments.map((comment: { user_id: any }) => comment.user_id)
+            ),
+          ];
+
+          const usersPromises = commentAuthorIds.map((user_id) =>
+            fetchUserByUserId(user_id)
+          );
+          const authors: any = await Promise.all(usersPromises);
+          setCommentAuthors(authors);
+        } else {
+          setCommentAuthors([]);
+        }
+      } catch (error) {
+        console.error("Error loading comments:", error);
+      } finally {
+        setCommentsLoading(false);
+      }
+    };
+
+    loadComments();
+  }, [post]);
+
+  function deletePost() {
+    Alert.alert(
+      "Delete Post",
+      "Are you sure you want to delete this post?",
+      [
+        {
+          text: "No",
+          style: "cancel",
+        },
+        {
+          text: "Yes",
+          onPress: async () => {
+            try {
+              await deletePostByPostId(JSON.parse(post).post_id);
+              router.push("/(tabs)/photos");
+            } catch (error) {
+              console.error("Error deleting post:", error);
+            }
+          },
+          style: "destructive",
+        },
+      ],
+      { cancelable: true }
+    );
+  }
+
+  return (
+    <>
+      <Post post={JSON.parse(post)} author={JSON.parse(author)} city={city} />
+      {loggedInUser.user_id === JSON.parse(post).user_id && (
+        <TouchableOpacity style={styles.button} onPress={deletePost}>
+          <Fontisto name="trash" size={24} color="white" />
+        </TouchableOpacity>
+      )}
+      <CommentsSection comments={comments} commentAuthors={commentAuthors} />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: "#FF0000",
+    paddingVertical: 10,
+    paddingHorizontal: 10,
+    borderRadius: 50,
+    width: 50,
+    height: 50,
+    justifyContent: "center",
+    alignItems: "center",
+    position: "absolute",
+    right: 10,
+    top: 10,
+  },
+});

--- a/app/(tabs)/post/[post_id].tsx
+++ b/app/(tabs)/post/[post_id].tsx
@@ -1,7 +1,12 @@
 import Post from "@/components/Post";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import {
+  useFocusEffect,
+  useGlobalSearchParams,
+  useLocalSearchParams,
+  useRouter,
+} from "expo-router";
 import CommentsSection from "../../../components/CommentsSection";
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useCallback } from "react";
 import {
   deletePostByPostId,
   fetchCityForSite,
@@ -21,6 +26,7 @@ import Fontisto from "@expo/vector-icons/Fontisto";
 
 export default function ViewPost() {
   const { loggedInUser } = useContext(UserContext);
+  // const [postLoading, setPostLoading] = useState(true);
   const [post, setPost] = useState<{
     user_id: number;
     body: string;
@@ -35,14 +41,16 @@ export default function ViewPost() {
   const [commentsLoading, setCommentsLoading] = useState(true);
   const [commentAuthors, setCommentAuthors] = useState([]);
   const post_id = Number(
-    useLocalSearchParams<{
+    useGlobalSearchParams<{
       post_id: string;
     }>().post_id
   );
-
   const router = useRouter();
 
-  useEffect(() => {
+  const loadPost = async () => {
+    setPost(null);
+    setAuthor(null);
+    SetComments([]);
     fetchPostById(post_id)
       .then(({ post }) => {
         setPost(post);
@@ -52,7 +60,13 @@ export default function ViewPost() {
         ]);
       })
       .catch((err) => console.error(`Loading error: ${err}`));
-  }, []);
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      loadPost();
+    }, [post_id])
+  );
 
   useEffect(() => {
     const loadComments = async () => {
@@ -84,7 +98,7 @@ export default function ViewPost() {
     };
 
     loadComments();
-  }, [post_id]);
+  }, [post]);
 
   function deletePost() {
     Alert.alert(
@@ -114,7 +128,6 @@ export default function ViewPost() {
 
   return (
     <>
-      <Text>NEW</Text>
       {post ? (
         <Post post={post} author={author} city={city} />
       ) : (

--- a/app/(tabs)/publish-post.tsx
+++ b/app/(tabs)/publish-post.tsx
@@ -13,7 +13,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import LocationSelector from "../components/LocationSelector";
+import LocationSelector from "../../components/LocationSelector";
 
 export default function publishPhoto() {
   const { photoUri } = useLocalSearchParams<{ photoUri: string }>();

--- a/app/(tabs)/view-post.tsx
+++ b/app/(tabs)/view-post.tsx
@@ -1,6 +1,6 @@
 import Post from "@/components/Post";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import CommentsSection from "../components/CommentsSection";
+import CommentsSection from "../../components/CommentsSection";
 import { useState, useEffect, useContext } from "react";
 import {
   deletePostByPostId,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,8 +6,6 @@ export default function RootLayout() {
     <UserProvider>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="view-post" options={{ headerShown: false }} />
-        <Stack.Screen name="publish-post" options={{ headerShown: false }} />
       </Stack>
     </UserProvider>
   );

--- a/app/user-photos.tsx
+++ b/app/user-photos.tsx
@@ -6,9 +6,12 @@ import {
   ActivityIndicator,
   StyleSheet,
   FlatList,
+  TouchableOpacity,
+  Dimensions,
 } from "react-native";
 import axios from "axios";
 import { fetchPosts } from "@/client/client.mjs";
+import { router } from "expo-router";
 
 const UserPhotos: React.FC = () => {
   const [photos, setPhotos] = useState<any>([]);
@@ -21,9 +24,9 @@ const UserPhotos: React.FC = () => {
     fetchPosts({ user_id: 1 })
       .then(({ posts }) => {
         const sortedPosts = posts.sort(
-          (a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+          (a: any, b: any) =>
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
         );
-        console.log(posts);
         setPhotos(sortedPosts);
         setLoading(false);
       })
@@ -31,7 +34,6 @@ const UserPhotos: React.FC = () => {
         setError("Failed to fetch photos");
         setLoading(false);
       });
-
   }, []);
 
   if (loading) {
@@ -56,7 +58,14 @@ const UserPhotos: React.FC = () => {
         data={photos}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => (
-          <Image src={item.img_url} style={styles.photo} />
+          <TouchableOpacity
+            onPress={() => {
+              console.log(item.post_id);
+              router.push(`post/${item.post_id}`);
+            }}
+          >
+            <Image src={item.img_url} style={styles.photo} />
+          </TouchableOpacity>
         )}
         numColumns={3}
         columnWrapperStyle={styles.row}
@@ -65,10 +74,12 @@ const UserPhotos: React.FC = () => {
   );
 };
 
+const screenWidth = Dimensions.get("window").width;
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    width: '97%',
+    width: "97%",
     padding: 10,
     backgroundColor: "#f2f2f2",
   },
@@ -83,8 +94,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   photo: {
-    width: "30%",
-    height: 100,
+    width: 0.3 * (screenWidth - 30),
+    height: 0.3 * (screenWidth - 30),
     margin: 5,
     borderRadius: 8,
   },

--- a/client/client.mjs
+++ b/client/client.mjs
@@ -15,6 +15,13 @@ export const fetchPosts = async (params = {}) => {
     .catch(defaultCatch);
 };
 
+export const fetchPostById = async (post_id) => {
+  return apiClient
+    .get(`posts/${post_id}`)
+    .then(({ data }) => data)
+    .catch(defaultCatch);
+};
+
 export const fetchUsers = async () => {
   return apiClient
     .get("users")
@@ -86,3 +93,30 @@ export const deletePostByPostId = async (post_id) => {
     defaultCatch(error);
   }
 };
+
+export async function getCityByCoordinates(latitude, longitude) {
+  const url = `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json&addressdetails=1`;
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+
+    if (data && data.address) {
+      const city =
+        data.address.city || data.address.town || data.address.village || "";
+      return city;
+    } else {
+      console.log(url);
+      console.log(data);
+      return "";
+    }
+  } catch (error) {
+    console.error("Error fetching city:", error);
+    return "";
+  }
+}
+
+export async function fetchCityForSite(site_id) {
+  const { site } = await fetchSiteBySiteId(site_id);
+  const city = await getCityByCoordinates(site.latitude, site.longitude);
+  return city;
+}

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { convertDateShort } from "../client/utils";
 import { useRouter } from "expo-router";
+const defaultAuthorUri = "https://www.flickr.com/photos/loopzilla/2203595978";
 
 export default function Post({
   post,
@@ -26,20 +27,28 @@ export default function Post({
   author: any;
   city: string;
 }) {
-  const { body, img_url, created_at } = post;
+  const { body, img_url, created_at, post_id } = post;
   const router = useRouter();
 
   return (
     <>
-      <View style={styles.userContainer}>
-        <Image source={{ uri: author.avatar_url }} style={styles.avatar} />
-        <Text style={styles.username}>{author.username}</Text>
-        <Text>{city}</Text>
-      </View>
+      {author ? (
+        <View style={styles.userContainer}>
+          <Image source={{ uri: author.avatar_url }} style={styles.avatar} />
+          <Text style={styles.username}>{author.username}</Text>
+          <Text>{city}</Text>
+        </View>
+      ) : (
+        <View>
+          <Image source={{ uri: defaultAuthorUri }} style={styles.avatar} />
+          <Text style={styles.username}>loading...</Text>
+          <Text>{city}</Text>
+        </View>
+      )}
       <TouchableOpacity
         onPress={() =>
           router.push({
-            pathname: "/view-post",
+            pathname: `/post/${post_id}`,
             params: {
               post: JSON.stringify(post),
               author: JSON.stringify(author),

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -46,16 +46,11 @@ export default function Post({
         </View>
       )}
       <TouchableOpacity
-        onPress={() =>
+        onPress={() => {
           router.push({
             pathname: `/post/${post_id}`,
-            params: {
-              post: JSON.stringify(post),
-              author: JSON.stringify(author),
-              city: city,
-            },
-          })
-        }
+          });
+        }}
       >
         <Image source={{ uri: img_url }} style={styles.image} />
         <Text> {body}</Text>


### PR DESCRIPTION
Added orange header from automatic react native, with included "home" navigation and back button away from home.

Making this appear on all screens solved issues of nav bar dissappearing when on specific tabs

Modified from query to parametric "/post/:post_id", functioning with feed view, and added this clickability to map Callouts and profile section.